### PR TITLE
Fixed Team Specific Detailed Notify

### DIFF
--- a/lib/honeybadger/honeybadger.rb
+++ b/lib/honeybadger/honeybadger.rb
@@ -4,7 +4,8 @@ require 'honeybadger/key_helpers'
 module Honeybadger
   class << self
     def notify_detailed(error_class, error_message, parameters = {})
-      notify(error_class: error_class, error_message: error_message, parameters: parameters)
+      # force class to be to string'd to prevent HB stackoverflow
+      notify(error_class: error_class.to_s, error_message: error_message, parameters: parameters)
     end
     
     # detection of :alert_team option in errors from sidekiq workers

--- a/lib/honeybadger/splitproject.rb
+++ b/lib/honeybadger/splitproject.rb
@@ -41,8 +41,7 @@ module Honeybadger
       def add_team_specific_detailed_notifier(team_postfix)
         Honeybadger.instance_eval do
           define_singleton_method("notify_detailed_#{team_postfix}") do |error_class, error_message, parameters = {}|
-            options = parameters.merge({ error_message: error_message })
-            send("notify_#{team_postfix}", { error_class: error_class }, options)
+            send("notify_#{team_postfix}", error_class: error_class, error_message: error_message, parameters: parameters)
           end
         end
       end

--- a/spec/honeybadger/honeybadger_spec.rb
+++ b/spec/honeybadger/honeybadger_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 require 'honeybadger/honeybadger'
 
+class Dummy
+end
+
 describe Honeybadger do
   
   describe "#notify_detailed" do
@@ -8,6 +11,12 @@ describe Honeybadger do
       expect(Honeybadger).to receive(:notify)
         .with(error_class: "error_class", error_message: "error_message", parameters: { :key => "val" }).once
       Honeybadger.notify_detailed("error_class", "error_message", { :key => "val" })
+    end
+    
+    it "should to string the error class to prevent stack overflow in HB" do
+      expect(Honeybadger).to receive(:notify)
+        .with(error_class: "Class", error_message: "error_message", parameters: { :key => "val" }).once
+      Honeybadger.notify_detailed(Dummy.class, "error_message", { :key => "val" })
     end
   end
   

--- a/spec/honeybadger/splitproject_spec.rb
+++ b/spec/honeybadger/splitproject_spec.rb
@@ -62,18 +62,18 @@ describe Honeybadger::Splitproject do
           end
           it "should add a notify detailed method that delegates to the original notify detailed method" do
             Honeybadger::Splitproject.add_notifiers_for_team("team1")
-            params = { :param1 => "1" }
-            expected_params = params.merge(error_message: "error_message", api_key: "api_key")
+            params = { param1: "1" }
+            expected_params = { error_class: "error_class", error_message: "error_message", parameters: params }
 
-            expect(Honeybadger).to receive(:notify).with({ :error_class => "error_class" }, expected_params).once
+            expect(Honeybadger).to receive(:notify).with(expected_params, { api_key: "api_key" }).once
 
             Honeybadger.notify_detailed_team1("error_class", "error_message", params)
           end
           it "should default the options hash if none is passed in for the notify detailed method" do
             Honeybadger::Splitproject.add_notifiers_for_team("team1")
-            expected_params = { error_message: "error_message", api_key: "api_key" }
+            expected_params = { error_class: "error_class", error_message: "error_message", parameters: {} }
 
-            expect(Honeybadger).to receive(:notify).with({ :error_class => "error_class" }, expected_params).once
+            expect(Honeybadger).to receive(:notify).with(expected_params, api_key: "api_key").once
 
             Honeybadger.notify_detailed_team1("error_class", "error_message")
           end
@@ -116,18 +116,18 @@ describe Honeybadger::Splitproject do
           end
           it "should add a notify detailed method that delegates to the original notify detailed method" do
             Honeybadger::Splitproject.add_notifiers_for_team("team1")
-            params = { :param1 => "1" }
-            expected_params = params.merge(error_message: "error_message")
+            params = { param1: "1" }
+            expected_params = { error_class: "error_class", error_message: "error_message", parameters: params }
 
-            expect(Honeybadger).to receive(:notify).with({ :error_class => "error_class" }, expected_params).once
+            expect(Honeybadger).to receive(:notify).with(expected_params, {}).once
 
             Honeybadger.notify_detailed_team1("error_class", "error_message", params)
           end
           it "should default the options hash if none is passed in for the notify detailed method" do
             Honeybadger::Splitproject.add_notifiers_for_team("team1")
-            expected_params = { error_message: "error_message" }
+            expected_params = { error_class: "error_class", error_message: "error_message", parameters: {} }
 
-            expect(Honeybadger).to receive(:notify).with({ :error_class => "error_class" }, expected_params).once
+            expect(Honeybadger).to receive(:notify).with(expected_params, {}).once
 
             Honeybadger.notify_detailed_team1("error_class", "error_message")
           end


### PR DESCRIPTION
- Was not passing the correct parameters in Ventura
- Force class name to be a string to prevent HB stack overflow
